### PR TITLE
Keyboard shortcuts to toggle grid overlay on and off created

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -25,5 +25,21 @@
     "file://*/*",
     "storage",
     "activeTab"
-  ]
+  ],
+  "commands": {
+    "toggle-columns": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+K",
+        "mac": "Command+Shift+K"
+      },
+      "description": "Toggle columns"
+    },
+    "toggle-lines": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+L",
+        "mac": "Command+Shift+L"
+      },
+      "description": "Toggle lines"
+    }
+  }
 }

--- a/src/executedScripts/background.js
+++ b/src/executedScripts/background.js
@@ -62,3 +62,32 @@ chrome.runtime.onInstalled.addListener(function () {
 chrome.tabs.onRemoved.addListener(function(tabId, removeInfo) {
     chrome.storage.sync.remove(tabId.toString());
 });
+
+
+//On keyboard command
+chrome.commands.onCommand.addListener(function (command) {
+  // this function is not scaleable
+
+  var method = '';
+  switch (command) {
+    case 'toggle-columns':
+      method = 'toggleGrid';
+      break;
+    case 'toggle-lines':
+      method = 'toggleHorizontalLines';
+      break;
+  }
+
+  chrome.tabs.query({currentWindow: true, active: true}, function (tabs) {
+    for (var i = 0; i < tabs.length; i++) {
+      if (chrome.runtime.lastError) {
+          console.warn("Whoops.. " + chrome.runtime.lastError.message);
+      } else {
+          if (tabs[i]) {
+              var currentId = tabs[i].id;
+              chrome.tabs.sendMessage(currentId, {method: method, tabId: currentId});
+          }
+      }
+    }
+  });
+});

--- a/src/executedScripts/grid.js
+++ b/src/executedScripts/grid.js
@@ -64,6 +64,20 @@
     chrome.runtime.onMessage.addListener(destroyListener);
     chromeMessageListeners.push(destroyListener);
 
+    function toggleGridListener(request, sender, sendResponse) {
+        if (request.method == "toggleGrid") {
+            if (document.getElementsByClassName('cb-grid-lines').length) {
+                request.method = 'destroy';
+                destroyListener(request, sender, sendResponse);
+            } else {
+                request.method = 'create';
+                createListener(request, sender, sendResponse);
+            }
+        }
+    }
+    chrome.runtime.onMessage.addListener(toggleGridListener);
+    chromeMessageListeners.push(toggleGridListener);
+
     /**
      * Adds the dynamically generated CSS for the grid
      * into the head of the document.
@@ -105,7 +119,7 @@
         var initialOffset = horizontalLinesContainer.dataset.hloffset || 0;
         horizontalLinesContainer.style.backgroundPositionY = (initialOffset - document.body.scrollTop) + 'px';
     }
-    
+
     function enableHorizontalLinesListener(request, sender, sendResponse) {
         if (request.method == "enableHorizontalLines") {
             chrome.storage.sync.get(request.tabId.toString(), function (item) {
@@ -127,11 +141,11 @@
     }
     chrome.runtime.onMessage.addListener(enableHorizontalLinesListener);
     chromeMessageListeners.push(enableHorizontalLinesListener);
-    
+
     function disableHorizontalLinesListener(request, sender, sendResponse) {
         if (request.method == "disableHorizontalLines") {
             horizontalLinesContainer = document.querySelector('.grid-overlay-horizontal');
-            
+
             if (horizontalLinesContainer) {
                 document.body.removeChild(document.getElementsByClassName('grid-overlay-horizontal')[0]);
             }
@@ -141,6 +155,22 @@
     }
     chrome.runtime.onMessage.addListener(disableHorizontalLinesListener);
     chromeMessageListeners.push(disableHorizontalLinesListener);
+
+    function toggleHorizontalLinesListener(request, sender, sendResponse) {
+        if (request.method == "toggleHorizontalLines") {
+            horizontalLinesContainer = document.querySelector('.grid-overlay-horizontal');
+
+            if (horizontalLinesContainer) {
+                request.method = 'disableHorizontalLines';
+                disableHorizontalLinesListener(request, sender, sendResponse);
+            } else {
+                request.method = 'enableHorizontalLines';
+                enableHorizontalLinesListener(request, sender, sendResponse);
+            }
+        }
+    }
+    chrome.runtime.onMessage.addListener(toggleHorizontalLinesListener);
+    chromeMessageListeners.push(toggleHorizontalLinesListener);
 
     /**
      * Inserts the base CSS styles for the grid into

--- a/src/popup.js
+++ b/src/popup.js
@@ -135,7 +135,7 @@ var popup = (function () {
         gridController.updateGrid(currentChromeTabId, settings.formData.gridForm.settings, settings.formData.advancedForm.settings);
         reportController.calculateReport(currentChromeTabId, settings.formData.gridForm.settings, settings.formData.advancedForm.settings);
     });
-    
+
     horizontalLinesToggle.addEventListener('click', function () {
         var settings = settingStorageController.saveSettings(currentChromeTabId, false);
         gridController.updateGrid(currentChromeTabId, settings.formData.gridForm.settings, settings.formData.advancedForm.settings);
@@ -269,6 +269,11 @@ var popup = (function () {
                             settings.formData.reportForm.settings, settings.formData.advancedForm.settings);
                     });
                 });
+
+                // call addCSS on load
+                // it's a hack to do posiible use keyboard commands to show grid and lines at the very first time (before checkbox click)
+                var settings = settingStorageController.saveSettings(currentChromeTabId, false);
+                gridController.updateGrid(currentChromeTabId, settings.formData.gridForm.settings, settings.formData.advancedForm.settings);
             }
         });
 


### PR DESCRIPTION
Ctrl+Shift+K - to toggle grid on and off (columns)
Ctrl+Shift+L - to toggle horizontal lines on and off

You should reload extension in Chrome, because manifest was changed

#54 