### PR TITLE
keep the grid overlay on as you navigate from page to page and/or ref…

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,6 +14,15 @@
     "scripts": ["src/executedScripts/background.js"],
     "persistent": false
   },
+  "content_scripts": [
+    {
+      "matches": [
+        "*://*/*",
+        "*://*/"
+      ],
+      "js": ["src/contentScripts/main.js"]
+    }
+  ],
   "web_accessible_resources": [
       "src/css/grid.css",
       "src/css/report.css"

--- a/src/contentScripts/main.js
+++ b/src/contentScripts/main.js
@@ -1,0 +1,123 @@
+// FIXME: this code duplicated from src/executedScripts/grid.js
+function initCSS (options, advancedOptions) {
+  // base styles
+  var css = document.createElement('link');
+  css.id = "base-grid-styles";
+  css.rel = "stylesheet";
+  css.type = "text/css";
+  css.href = chrome.extension.getURL('src/css/grid.css');
+
+  document.head.appendChild(css);
+
+  // FIXME: this code duplicated from src/controllers/gridController.js
+
+  // custom styles
+  var customCss = '.cb-grid-lines {' +
+      'width: 100' + (advancedOptions.viewports ? 'vw' : '%') +
+    '}';
+
+  // createGridContainer
+  customCss += '.grid-overlay-container {' +
+      'max-width:' + options.largeWidth + 'px;' +
+      'padding:0px ' + options.outterGutters + 'px;' +
+      'left:' + options.offsetX + 'px;' +
+    '}' +
+    '.grid-overlay-col {' +
+      'width:' + (100 / options.largeColumns) + '%;' +
+      'margin: 0 ' + (options.gutters / 2) + 'px;' +
+      'background: ' + advancedOptions.color + ';' +
+    '}' +
+    '.grid-overlay-col:first-child {' +
+      'margin-left:0px;' +
+    '}' +
+    '.grid-overlay-col:last-child {' +
+      'margin-right:0px;' +
+    '}' +
+    '.grid-overlay-horizontal {' +
+      'background-image: linear-gradient(to top, ' + advancedOptions.horizontalLinesColor + ' 1px, transparent 1px);' +
+      'background-size: 100% ' + options.rowGutters + 'px;' +
+      'background-repeat-y: repeat;' +
+      'background-position-y: ' + options.offsetY + 'px;' +
+    '} ';
+
+  // createSmallContainer
+  customCss += '@media (max-width:' + options.smallWidth + 'px) {' +
+      '.grid-overlay-col {' +
+        'width:' + (100 / options.smallColumns) + '%;' +
+        'margin: 0 ' + (options.mobileInnerGutters / 2) + 'px;' +
+        'background: ' + advancedOptions.color + ';' +
+      '}' +
+      '.grid-overlay-container {' +
+        'padding:0px ' + options.mobileOutterGutters + 'px;' +
+        'left:' + options.offsetX + 'px;' +
+      '}' +
+      '.grid-overlay-col:first-child {' +
+        'margin-left:0px;' +
+      '}' +
+      '.grid-overlay-col:nth-child(' + options.smallColumns + ') {' +
+        'margin-right:0px;' +
+      '}' +
+      '.grid-overlay-col:nth-child(n+' + (parseInt(options.smallColumns) + 1) + ') {' +
+        'display:none;' +
+      '}' +
+    '}'
+
+  var customGridStyles = document.createElement('style');
+  customGridStyles.id = "custom-grid-style";
+  customGridStyles.appendChild(document.createTextNode(customCss));
+
+  document.head.appendChild(customGridStyles);
+}
+
+function renderGrid (numColumns) {
+  // FIXME: this code duplicated from src/executedScripts/grid.js
+  var div = document.createElement('div');
+  div.setAttribute("class", "cb-grid-lines");
+
+  var output = '<div class="grid-overlay-container"> \
+      <div class="grid-overlay-row">';
+
+  for (var i = 0; i < numColumns; i += 1) {
+      output += '<div class="grid-overlay-col"></div>';
+  }
+
+  output += '</div> \
+      </div>';
+
+  div.innerHTML = output;
+  document.body.appendChild(div);
+}
+
+function renderHorizontalLines (offsetY) {
+  // FIXME: this code duplicated from src/executedScripts/grid.js
+  var horizontalLinesContainer;
+  var documentScrollListener = function (e) {
+      // emulate static position for container background (horizontal lines)
+      var initialOffset = horizontalLinesContainer.dataset.hloffset || 0;
+      horizontalLinesContainer.style.backgroundPositionY = (initialOffset - document.body.scrollTop) + 'px';
+  }
+
+  horizontalLinesContainer = document.createElement('div');
+  horizontalLinesContainer.setAttribute("class", "grid-overlay-horizontal");
+  horizontalLinesContainer.style.backgroundPositionY = (offsetY - document.body.scrollTop) + 'px';
+  document.body.appendChild(horizontalLinesContainer);
+
+  horizontalLinesContainer.dataset.hloffset = offsetY;
+
+  window.addEventListener('scroll', documentScrollListener, false);
+}
+
+chrome.storage.sync.get(function (storage) {
+  chrome.extension.sendMessage({ type: 'getTabId' }, function (tabId) {
+      if (storage.hasOwnProperty(tabId)) {
+        storage = storage[tabId];
+
+        initCSS(storage.formData.gridForm.settings, storage.formData.advancedForm.settings);
+
+        if (storage.showGrid)
+          renderGrid(storage.formData.gridForm.settings.largeColumns || 16);
+        if (storage.showHorizontalLines)
+          renderHorizontalLines(storage.formData.gridForm.settings.offsetY);
+      }
+  });
+});

--- a/src/controllers/settingStorageController.js
+++ b/src/controllers/settingStorageController.js
@@ -36,6 +36,9 @@ var settingStorageController = (function () {
         // UI Tab stored state
         activeTabPanelId: EMPTY_VALUE,
         activeTabLabelId: EMPTY_VALUE,
+        // Displaing the grid settings
+        showGrid: false,
+        showHorizontalLines: false,
         // Form data for grid settings
         formData: {
             gridForm: {
@@ -192,6 +195,9 @@ var settingStorageController = (function () {
                 }
             }
 
+            // Load the grid displaing settings
+            settings.showGrid = document.getElementById('gridToggle').checked;
+            settings.showHorizontalLines = document.getElementById('horizontalLinesToggle').checked;
 
             // Save our data structure back to storage, to store any default values
             // This save call will also sync our UI state with our in-memory global settings object
@@ -230,6 +236,9 @@ var settingStorageController = (function () {
         settings.activeTabLabelId = dataToStore[currentChromeTabId].activeTabLabelId;
         settings.activeTabPanelId = dataToStore[currentChromeTabId].activeTabPanelId;
 
+        // Save the grid displaing settings
+        dataToStore[currentChromeTabId].showGrid = document.getElementById('gridToggle').checked;
+        dataToStore[currentChromeTabId].showHorizontalLines = document.getElementById('horizontalLinesToggle').checked;
 
         //Go through each settings ID in each form and pull the data from the HTML state into an object for storage
         for (var formName in settings.formData) {

--- a/src/executedScripts/background.js
+++ b/src/executedScripts/background.js
@@ -63,7 +63,7 @@ chrome.runtime.onInstalled.addListener(function () {
  */
 
 chrome.browserAction.setTitle({
-    title:'Use ( Ctrl / Command + Shift + A ) to activate Design Grid Overlay' 
+    title:'Use ( Ctrl / Command + Shift + A ) to activate Design Grid Overlay'
 });
 
 
@@ -100,4 +100,10 @@ chrome.commands.onCommand.addListener(function (command) {
       }
     }
   });
+});
+
+// this listener helps to content_scripts to know the current tab ID
+chrome.extension.onMessage.addListener(function (message, sender, sendResponse) {
+  if (message.type === 'getTabId')
+      sendResponse(sender.tab.id);
 });

--- a/src/executedScripts/grid.js
+++ b/src/executedScripts/grid.js
@@ -41,7 +41,10 @@
                     </div>';
 
                 div.innerHTML = output;
-                document.body.appendChild(div);
+
+                // double grid fix
+                if (document.getElementsByClassName('cb-grid-lines').length < 1)
+                  document.body.appendChild(div);
 
                 respond(1);
             });


### PR DESCRIPTION
#61 

## Use cases
- User enables the grid (and/or horizontal lines) overlay. User refreshes the page. After the page refresh the grid (and/or horizontal lines) overlay is rendering automatically;
- User enables the grid (and/or horizontal lines) overlay. User opens a new URL (by link or directly input) in current tab. After the page refresh the grid (and/or horizontal lines) overlay is rendering automatically.

## It don't work
- When user follows the `targer="_blank"` link (which opens in a new tab); 
- When user use extension in local file (the `file://` protocol). It's necessary to use web server. ([Chrome web server](https://chrome.google.com/webstore/detail/web-server-for-chrome/ofhbbkphhbklhfoeikjpcbhemlocgigb) will work fine).

## Issues 
- Add keypress listener in content_script and let user use keyboard shortcuts without opening the popup (enhancement);
- After a page refresh, when the grid overlay is rendered with non-default options, if user opens the popup, options set to default and the grid re-renders with default options.